### PR TITLE
Added an option to use a common anode RGB LED.

### DIFF
--- a/esp8266_artnet_dmx512/esp8266_artnet_dmx512.ino
+++ b/esp8266_artnet_dmx512/esp8266_artnet_dmx512.ino
@@ -269,6 +269,40 @@ void loop() {
 } // loop
 
 
+#ifdef COMMON_ANODE
+
+void singleRed() {
+  digitalWrite(LED_R, LOW);
+  digitalWrite(LED_G, HIGH);
+  digitalWrite(LED_B, HIGH);
+}
+
+void singleGreen() {
+  digitalWrite(LED_R, HIGH);
+  digitalWrite(LED_G, LOW);
+  digitalWrite(LED_B, HIGH);
+}
+
+void singleBlue() {
+  digitalWrite(LED_R, HIGH);
+  digitalWrite(LED_G, HIGH);
+  digitalWrite(LED_B, LOW);
+}
+
+void singleYellow() {
+  digitalWrite(LED_R, LOW);
+  digitalWrite(LED_G, LOW);
+  digitalWrite(LED_B, HIGH);
+}
+
+void allBlack() {
+  digitalWrite(LED_R, HIGH);
+  digitalWrite(LED_G, HIGH);
+  digitalWrite(LED_B, HIGH);
+}
+
+#else
+
 void singleRed() {
   digitalWrite(LED_R, HIGH);
   digitalWrite(LED_G, LOW);
@@ -298,3 +332,5 @@ void allBlack() {
   digitalWrite(LED_G, LOW);
   digitalWrite(LED_B, LOW);
 }
+
+#endif


### PR DESCRIPTION
This change simply reverses the high/low sense of the LED outputs, for use with a common anode RGB LED instead of a common cathode.

Because this difference is determined by hardware design I figured it made more sense to make in an #ifdef rather than making it configurable at run time.